### PR TITLE
Made the error initialization catch statements more informative

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ And use it in your website:
 			window.editor = editor;
 		} )
 		.catch( error => {
-			console.error( 'There was a problem with initializing the editor', error );
+			console.error( 'There was a problem initializing the editor.', error );
 		} );
 </script>
 ```
@@ -61,7 +61,7 @@ ClassicEditor
 		window.editor = editor;
 	} )
 	.catch( error => {
-		console.error( 'There was a problem with initializing the editor', error );
+		console.error( 'There was a problem initializing the editor.', error );
 	} );
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ And use it in your website:
 		.then( editor => {
 			window.editor = editor;
 		} )
-		.catch( err => {
-			console.error( err.stack );
+		.catch( error => {
+			console.error( 'There was a problem with initializing the editor', error );
 		} );
 </script>
 ```
@@ -60,8 +60,8 @@ ClassicEditor
 	.then( editor => {
 		window.editor = editor;
 	} )
-	.catch( err => {
-		console.error( err.stack );
+	.catch( error => {
+		console.error( 'There was a problem with initializing the editor', error );
 	} );
 ```
 

--- a/sample/index.html
+++ b/sample/index.html
@@ -32,8 +32,8 @@
 		.then( editor => {
 			window.editor = editor;
 		} )
-		.catch( err => {
-			console.error( err.stack );
+		.catch( error => {
+			console.error( 'There was a problem with initializing the editor', error );
 		} );
 </script>
 

--- a/sample/index.html
+++ b/sample/index.html
@@ -33,7 +33,7 @@
 			window.editor = editor;
 		} )
 		.catch( error => {
-			console.error( 'There was a problem with initializing the editor', error );
+			console.error( 'There was a problem initializing the editor.', error );
 		} );
 </script>
 

--- a/tests/manual/ckeditor-amd-version.html
+++ b/tests/manual/ckeditor-amd-version.html
@@ -37,8 +37,8 @@
 			.then( editor => {
 				window.editor = editor;
 			} )
-			.catch( err => {
-				console.error( err.stack );
+			.catch( error => {
+				console.error( 'There was a problem with initializing the editor', error );
 			} );
 	} );
 
@@ -50,8 +50,8 @@
 			.then( editor => {
 				window.editor = editor;
 			} )
-			.catch( err => {
-				console.error( err.stack );
+			.catch( error => {
+				console.error( 'There was a problem with initializing the editor', error );
 			} );
 	} );
 </script>

--- a/tests/manual/ckeditor-amd-version.html
+++ b/tests/manual/ckeditor-amd-version.html
@@ -38,7 +38,7 @@
 				window.editor = editor;
 			} )
 			.catch( error => {
-				console.error( 'There was a problem with initializing the editor', error );
+				console.error( 'There was a problem initializing the editor.', error );
 			} );
 	} );
 
@@ -51,7 +51,7 @@
 				window.editor = editor;
 			} )
 			.catch( error => {
-				console.error( 'There was a problem with initializing the editor', error );
+				console.error( 'There was a problem initializing the editor.', error );
 			} );
 	} );
 </script>

--- a/tests/manual/ckeditor-cjs-version.js
+++ b/tests/manual/ckeditor-cjs-version.js
@@ -13,5 +13,5 @@ ClassicEditor.create( document.querySelector( '#editor' ) )
 		window.editor = editor;
 	} )
 	.catch( error => {
-		console.error( 'There was a problem with initializing the editor', error );
+		console.error( 'There was a problem initializing the editor.', error );
 	} );

--- a/tests/manual/ckeditor-cjs-version.js
+++ b/tests/manual/ckeditor-cjs-version.js
@@ -12,6 +12,6 @@ ClassicEditor.create( document.querySelector( '#editor' ) )
 	.then( editor => {
 		window.editor = editor;
 	} )
-	.catch( err => {
-		console.error( err.stack );
+	.catch( error => {
+		console.error( 'There was a problem with initializing the editor', error );
 	} );

--- a/tests/manual/ckeditor-global-version.html
+++ b/tests/manual/ckeditor-global-version.html
@@ -38,7 +38,7 @@
 			window.editor = editor;
 		} )
 		.catch( error => {
-			console.error( 'There was a problem with initializing the editor', error );
+			console.error( 'There was a problem initializing the editor.', error );
 		} );
 
 	ClassicEditor
@@ -49,7 +49,7 @@
 			window.editor = editor;
 		} )
 		.catch( error => {
-			console.error( 'There was a problem with initializing the editor', error );
+			console.error( 'There was a problem initializing the editor.', error );
 		} );
 </script>
 

--- a/tests/manual/ckeditor-global-version.html
+++ b/tests/manual/ckeditor-global-version.html
@@ -37,8 +37,8 @@
 		.then( editor => {
 			window.editor = editor;
 		} )
-		.catch( err => {
-			console.error( err.stack );
+		.catch( error => {
+			console.error( 'There was a problem with initializing the editor', error );
 		} );
 
 	ClassicEditor
@@ -48,8 +48,8 @@
 		.then( editor => {
 			window.editor = editor;
 		} )
-		.catch( err => {
-			console.error( err.stack );
+		.catch( error => {
+			console.error( 'There was a problem with initializing the editor', error );
 		} );
 </script>
 

--- a/tests/manual/ckeditor.js
+++ b/tests/manual/ckeditor.js
@@ -11,6 +11,6 @@ ClassicEditor.create( document.querySelector( '#editor' ) )
 	.then( editor => {
 		window.editor = editor;
 	} )
-	.catch( err => {
-		console.error( err.stack );
+	.catch( error => {
+		console.error( 'There was a problem with initializing the editor', error );
 	} );

--- a/tests/manual/ckeditor.js
+++ b/tests/manual/ckeditor.js
@@ -12,5 +12,5 @@ ClassicEditor.create( document.querySelector( '#editor' ) )
 		window.editor = editor;
 	} )
 	.catch( error => {
-		console.error( 'There was a problem with initializing the editor', error );
+		console.error( 'There was a problem initializing the editor.', error );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Example error handling in build samples is now more informative. Closes ckeditor/ckeditor5#1803.

---

### Additional information

There are 5 PRs in total, for each of the following packages:

* ckeditor5-build-balloon
* ckeditor5-build-balloon-block
* ckeditor5-build-classic
* ckeditor5-build-decoupled-document
* ckeditor5-build-inline